### PR TITLE
Add warning about missing contact information

### DIFF
--- a/gluon-config-mode-contact-obligatory/files/lib/gluon/config-mode/wizard/0500-contact-info.lua
+++ b/gluon-config-mode-contact-obligatory/files/lib/gluon/config-mode/wizard/0500-contact-info.lua
@@ -19,6 +19,19 @@ function M.section(form)
   o.rmempty = not site.owner.obligatory
   o.datatype = "string"
   o.description = i18n.translate("e.g. E-mail or phone number")
+  o.validate = function(self, val)
+    if val == nil then
+      self.section.error = {
+        [1] = { 
+          i18n.translate(
+            'If you are really sure that you do not want to add any '
+              .. 'contact info enter a single space character'
+          )
+        }
+      }
+    end
+    return val
+  end
   o.maxlen = 140
 end
 


### PR DESCRIPTION
Fix für #2. Das sollte es (in etwa) tun. Man bekommt weiter zusätzlich eine Warnung über falsch ausgefüllte Felder, aber das scheint am Template zu liegen. Das müsste man da genauer debuggen.