### PR TITLE
prettyPeer translation

### DIFF
--- a/gluon-status-page-en/src/js/lib/gui/statistics.js
+++ b/gluon-status-page-en/src/js/lib/gui/statistics.js
@@ -178,7 +178,7 @@ define(["lib/helper"], function (Helper) {
 
   function prettyPackets(d) {
     var v = Helper.formatNumberFixed(d, 0)
-    return v + " Pakete/s"
+    return v + " Packets/s"
   }
 
   function prettyPrefix(prefixes, step, d) {

--- a/gluon-status-page-en/src/js/lib/gui/statistics.js
+++ b/gluon-status-page-en/src/js/lib/gui/statistics.js
@@ -171,9 +171,9 @@ define(["lib/helper"], function (Helper) {
 
   function prettyPeer(d) {
     if (d === null)
-      return "nicht verbunden"
+      return "not connected"
     else
-      return "verbunden (" + prettyUptime(d.established) + ")"
+      return "connected (" + prettyUptime(d.established) + ")"
   }
 
   function prettyPackets(d) {

--- a/gluon-status-page-en/src/js/lib/gui/statistics.js
+++ b/gluon-status-page-en/src/js/lib/gui/statistics.js
@@ -230,7 +230,7 @@ define(["lib/helper"], function (Helper) {
   }
 
   function prettyNVRAM(usage) {
-    return Helper.formatNumber(usage * 100, 3) + "% belegt"
+    return Helper.formatNumber(usage * 100, 3) + "% used"
   }
 
   function prettyLoad(load) {


### PR DESCRIPTION
prettyPeer was still in german. Now translated to english.