### PR TITLE
Makefile - gluon-status-page-en-api does not exist

### DIFF
--- a/gluon-status-page-en/Makefile
+++ b/gluon-status-page-en/Makefile
@@ -36,7 +36,7 @@ define Package/gluon-status-page-en
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=Adds a status page showing information about the node.
-  DEPENDS:=+gluon-status-page-en-api
+  DEPENDS:=+gluon-status-page-api
 endef
 
 define Package/gluon-status-page-en/description


### PR DESCRIPTION
gluon-status-page-en-api does not exist. It also seems, that translation of gluon-status-page-api isn't necessary, as it doesn't contain any german text anyhow.